### PR TITLE
TimingDiagram: ignore wave string length for async lanes when computing total periods

### DIFF
--- a/schemdraw/logic/timing.py
+++ b/schemdraw/logic/timing.py
@@ -176,7 +176,7 @@ class TimingDiagram(Element):
         foot: dict = self.wave.get('foot', {})
 
         height = (self.yheight+self.ygap)*len(signals_flat)
-        periods = max(len(w.get('wave', [])) for w in signals_flat)
+        periods = max(len(w.get('wave', [])) for w in signals_flat if 'async' not in w)
         periods = max(periods, (max(w.get('async', [0])[-1] for w in signals_flat)))
         if self.grid:
             self._drawgrid(periods, height)


### PR DESCRIPTION
This PR fixes a width computation edge case in schemdraw.logic.TimingDiagram: when an asynchronous lane has a wave string longer than its last async timestamp, the diagram’s total width (grid columns) is currently extended by the wave length, leaving empty grid space at the right.
This is a mirrored/reversed variant of the issue discussed in #5  and fixed in 94769b9.

Minimum repro:

Consider the following timing:

```
timing_data = {
    'signal': [
  {'name': 'clk', 'wave': 'p...'},
  {'name': 'S0',  'wave': 'lhlhlhlh', 'async': [ 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2]},
]
}
```
Current result:
<img width="442" height="99" alt="no_fix" src="https://github.com/user-attachments/assets/4113290a-f325-482f-9c40-9e7c9e6cf234" />
expected / with fix:
<img width="369" height="99" alt="fixed" src="https://github.com/user-attachments/assets/d45a4ad8-db81-4350-b80c-fbb98b67d43b" />


