### PR TITLE
Fix greedy regex in mathtextsvg() for \sqrt and \overline

### DIFF
--- a/schemdraw/backends/svgtext.py
+++ b/schemdraw/backends/svgtext.py
@@ -219,13 +219,13 @@ def mathtextsvg(text: str) -> ET.Element:
                 t = t.replace(sup, fr'<tspan baseline-shift="-2" font-size="smaller">{sup[1]}</tspan>')
 
         # \sqrt
-        sups = re.split(r'(\\sqrt{.*})', t)
+        sups = re.split(r'(\\sqrt{.*?})', t)
         for sup in sups:
             if sup.startswith(r'\sqrt{'):
                 t = t.replace(sup, fr'√\overline{{{sup[6:-1]}}}')
 
         # \overline
-        sups = re.split(r'(\\overline{.*})', t)
+        sups = re.split(r'(\\overline{.*?})', t)
         for sup in sups:
             if sup.startswith(r'\overline{'):
                 t = t.replace(sup, f'<tspan text-decoration="overline">{sup[10:-1]}</tspan>')


### PR DESCRIPTION
## Summary

- Fixes greedy regex patterns (`.*`) to non-greedy (`.*?`) for `\sqrt{}` and `\overline{}` in `mathtextsvg()`
- The superscript/subscript patterns already use non-greedy matching correctly — this was an inconsistency

## Problem

With input like `$\sqrt{a} + \sqrt{c}$`, the greedy `.*` matches from the first `{` to the **last** `}`, producing malformed SVG output or `ET.ParseError`.

## Changes

`schemdraw/backends/svgtext.py` lines 222, 228: `.*` → `.*?`

Fixes #90