### PR TITLE
Escape XML special characters in mathtextsvg() tspan content

### DIFF
--- a/schemdraw/backends/svgtext.py
+++ b/schemdraw/backends/svgtext.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Optional
 from xml.etree import ElementTree as ET
+from xml.sax.saxutils import escape as xml_escape
 import string
 import re
 
@@ -195,12 +196,12 @@ def mathtextsvg(text: str) -> ET.Element:
                     chrs = ''.join([numsuperscripts[c] for c in chrs])
                     t = t.replace(sup, chrs)
                 else:
-                    t = t.replace(sup, f'<tspan baseline-shift="super" font-size="smaller">{chrs}</tspan>')
+                    t = t.replace(sup, f'<tspan baseline-shift="super" font-size="smaller">{xml_escape(chrs)}</tspan>')
         # Find superscripts single char
         sups = re.split(r'(\^.)', t)
         for sup in sups:
             if sup.startswith('^'):
-                t = t.replace(sup, f'<tspan baseline-shift="super" font-size="smaller">{sup[1]}</tspan>')
+                t = t.replace(sup, f'<tspan baseline-shift="super" font-size="smaller">{xml_escape(sup[1])}</tspan>')
 
         # Find subscripts within {}
         sups = re.split(r'(\_\{.*?\})', t)
@@ -211,24 +212,24 @@ def mathtextsvg(text: str) -> ET.Element:
                     chrs = ''.join([numsubscripts[c] for c in chrs])
                     t = t.replace(sup, chrs)
                 else:
-                    t = t.replace(sup, f'<tspan baseline-shift="-2" font-size="smaller">{chrs}</tspan>')
+                    t = t.replace(sup, f'<tspan baseline-shift="-2" font-size="smaller">{xml_escape(chrs)}</tspan>')
         # Find subscripts single char
         sups = re.split(r'(\_.)', t)
         for sup in sups:
             if sup.startswith('_'):
-                t = t.replace(sup, fr'<tspan baseline-shift="-2" font-size="smaller">{sup[1]}</tspan>')
+                t = t.replace(sup, f'<tspan baseline-shift="-2" font-size="smaller">{xml_escape(sup[1])}</tspan>')
 
         # \sqrt
         sups = re.split(r'(\\sqrt{.*})', t)
         for sup in sups:
             if sup.startswith(r'\sqrt{'):
-                t = t.replace(sup, fr'√\overline{{{sup[6:-1]}}}')
+                t = t.replace(sup, fr'√\overline{{{xml_escape(sup[6:-1])}}}')
 
         # \overline
         sups = re.split(r'(\\overline{.*})', t)
         for sup in sups:
             if sup.startswith(r'\overline{'):
-                t = t.replace(sup, f'<tspan text-decoration="overline">{sup[10:-1]}</tspan>')
+                t = t.replace(sup, f'<tspan text-decoration="overline">{xml_escape(sup[10:-1])}</tspan>')
         svgtext += t
 
     svgtext = '<tspan>' + svgtext + '</tspan>'

--- a/test/test_svgtext.py
+++ b/test/test_svgtext.py
@@ -1,0 +1,88 @@
+''' Tests for SVG text rendering, specifically mathtextsvg() in backends/svgtext.py
+
+    Verifies that XML special characters in math expressions (superscripts,
+    subscripts, sqrt, overline) do not produce malformed SVG.
+'''
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from schemdraw.backends.svgtext import mathtextsvg
+
+
+def test_basic_superscript():
+    ''' Basic superscript should produce valid tspan '''
+    result = mathtextsvg('$x^{2}$')
+    assert result is not None
+    assert result.tag == 'tspan'
+
+
+def test_basic_subscript():
+    ''' Basic subscript should produce valid tspan '''
+    result = mathtextsvg('$V_{out}$')
+    assert result is not None
+    assert result.tag == 'tspan'
+
+
+def test_superscript_with_ampersand():
+    ''' Ampersand in superscript should not crash XML parser '''
+    result = mathtextsvg('$x^{a&b}$')
+    assert result is not None
+
+
+def test_subscript_with_angle_brackets():
+    ''' Angle brackets in subscript should not crash XML parser '''
+    result = mathtextsvg('$V_{<out>}$')
+    assert result is not None
+
+
+def test_superscript_single_char_special():
+    ''' Single-char superscript with special char '''
+    result = mathtextsvg('$x^>$')
+    assert result is not None
+
+
+def test_subscript_single_char_special():
+    ''' Single-char subscript with special char '''
+    result = mathtextsvg('$x_<$')
+    assert result is not None
+
+
+def test_overline_with_special_chars():
+    ''' Overline content with special chars should not crash '''
+    result = mathtextsvg(r'$\overline{a&b}$')
+    assert result is not None
+
+
+def test_sqrt_with_special_chars():
+    ''' Sqrt content with special chars should not crash '''
+    result = mathtextsvg(r'$\sqrt{a&b}$')
+    assert result is not None
+
+
+def test_plain_text_unchanged():
+    ''' Non-math text should pass through unchanged '''
+    result = mathtextsvg('Hello World')
+    assert result.text == 'Hello World'
+
+
+def test_mixed_math_and_text():
+    ''' Text with embedded math expression '''
+    result = mathtextsvg('Value: $x^{2}$ volts')
+    assert result is not None
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f'  PASS: {test.__name__}')
+            passed += 1
+        except Exception as e:
+            print(f'  FAIL: {test.__name__}: {e}')
+            failed += 1
+    print(f'\n{passed} passed, {failed} failed, {passed + failed} total')
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

- Escapes XML special characters (`&`, `<`, `>`) in text content before inserting into `<tspan>` elements in `mathtextsvg()`
- Adds `test/test_svgtext.py` with 10 test cases covering special characters in all math patterns

## Problem

Text extracted from math superscripts, subscripts, `\sqrt`, and `\overline` patterns was inserted raw into XML `<tspan>` elements. Characters like `&`, `<`, `>` in these contexts caused `ET.fromstring()` to fail with `ParseError`.

For example, `$V_{<out>}$` or `$x^{a&b}$` would crash SVG text rendering.

## Changes

- `schemdraw/backends/svgtext.py`: Import `xml.sax.saxutils.escape` and apply it to all content inserted into tspan elements (lines 199, 204, 215, 220, 226, 232)
- `test/test_svgtext.py`: New test file verifying special characters in superscripts, subscripts, sqrt, overline, and mixed text

## Test results

Without fix: 5 of 10 tests fail with `ParseError`
With fix: 10 of 10 tests pass

Fixes #91