### PR TITLE
Fix raster images added twice to SVG output

### DIFF
--- a/schemdraw/backends/svg.py
+++ b/schemdraw/backends/svg.py
@@ -596,7 +596,6 @@ class Figure:
             image_b64 = base64.encodebytes(imgdat).decode()
             et = ET.Element('image')
             et.set('xlink:href', f'data:image/{imgfmt};base64,{image_b64}')
-            self.svgelements.append((zorder, et))
             self._need_xlink = True
 
             et.set('x', fmt(x0))

--- a/test/test_raster_image.py
+++ b/test/test_raster_image.py
@@ -1,0 +1,42 @@
+''' Test that raster images are not duplicated in SVG output.
+
+    Verifies fix for issue #92: the SVG backend's image() method was
+    appending raster image elements to svgelements twice.
+'''
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from schemdraw.backends.svg import Figure
+from schemdraw.types import BBox
+
+
+def test_raster_image_not_duplicated():
+    ''' A raster image should appear exactly once in svgelements '''
+    fig = Figure(bbox=BBox(0, 0, 200, 200), inches_per_unit=0.5, fontsize=14, font='sans-serif')
+
+    # Use the existing test PNG in the test directory
+    test_png = os.path.join(os.path.dirname(__file__), 'ArduinoUNO.png')
+    if not os.path.exists(test_png):
+        print('  SKIP: test PNG not found')
+        return
+
+    fig.image(image=test_png, xy=(0, 0), width=100, height=100)
+    image_count = sum(1 for _, el in fig.svgelements if el.tag == 'image')
+    assert image_count == 1, f'Expected 1 image element, got {image_count}'
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f'  PASS: {test.__name__}')
+            passed += 1
+        except Exception as e:
+            print(f'  FAIL: {test.__name__}: {e}')
+            failed += 1
+    print(f'\n{passed} passed, {failed} failed, {passed + failed} total')
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

- Removes duplicate `svgelements.append()` call for raster images in the SVG backend

## Problem

In `schemdraw/backends/svg.py`, the `image()` method appends raster image elements to `self.svgelements` twice:
- Line 599: inside the `else` branch (raster images only)
- Line 608: shared code path (all image types)

SVG images are only appended at line 608 (correct). Raster images get appended at both lines, resulting in every raster image appearing twice in the final SVG.

## Changes

- `schemdraw/backends/svg.py`: Remove the early `self.svgelements.append()` at line 599, keeping only the shared one at line 608
- `test/test_raster_image.py`: New test verifying raster images appear exactly once

## Test results

Without fix: `Expected 1 image element, got 2`
With fix: `1 passed`

Fixes #92