### PR TITLE
Handle edge cases in linspace() for num < 2

### DIFF
--- a/schemdraw/util.py
+++ b/schemdraw/util.py
@@ -80,6 +80,8 @@ def dot(a: XY, b: Tuple[Tuple[float, float], Tuple[float, float]]) -> Point:
 
 def linspace(start: float, stop: float, num: int = 50) -> list[float]:
     ''' List of evenly spaced numbers '''
+    if num < 2:
+        return [start] if num == 1 else []
     step = (stop - start) / (num - 1)
     return [start+step*i for i in range(num)]
 

--- a/test/test_linspace.py
+++ b/test/test_linspace.py
@@ -1,0 +1,54 @@
+''' Tests for util.linspace() edge cases.
+
+    Verifies fix for issue #93: linspace(start, stop, num=1) raised
+    ZeroDivisionError.
+'''
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from schemdraw.util import linspace
+
+
+def test_linspace_num_1():
+    ''' linspace with num=1 should return [start] '''
+    result = linspace(0, 10, num=1)
+    assert result == [0], f'Expected [0], got {result}'
+
+
+def test_linspace_num_0():
+    ''' linspace with num=0 should return empty list '''
+    result = linspace(0, 10, num=0)
+    assert result == [], f'Expected [], got {result}'
+
+
+def test_linspace_num_2():
+    ''' linspace with num=2 should return [start, stop] '''
+    result = linspace(0, 10, num=2)
+    assert len(result) == 2
+    assert result[0] == 0
+    assert result[1] == 10
+
+
+def test_linspace_default():
+    ''' linspace with default num should return 50 elements '''
+    result = linspace(0, 1)
+    assert len(result) == 50
+    assert result[0] == 0
+    assert abs(result[-1] - 1.0) < 1e-10
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f'  PASS: {test.__name__}')
+            passed += 1
+        except Exception as e:
+            print(f'  FAIL: {test.__name__}: {e}')
+            failed += 1
+    print(f'\n{passed} passed, {failed} failed, {passed + failed} total')
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

- Fixes `ZeroDivisionError` when calling `linspace()` with `num=1`

## Problem

`linspace(start, stop, num=1)` computes `step = (stop - start) / (num - 1)`, which divides by zero. This function is used internally by `roundcorners()` and `SegmentArc.get_bbox()`.

## Changes

- `schemdraw/util.py`: Return `[start]` when `num=1` and `[]` when `num=0`, consistent with `numpy.linspace` behavior
- `test/test_linspace.py`: New test file covering `num=0`, `num=1`, `num=2`, and default cases

## Test results

Without fix: `test_linspace_num_1` fails with `ZeroDivisionError`
With fix: all 4 tests pass

Fixes #93