### PR TITLE
Fix Drawing.undo() crash on empty or single-element drawings

### DIFF
--- a/schemdraw/schemdraw.py
+++ b/schemdraw/schemdraw.py
@@ -348,13 +348,20 @@ class Drawing:
 
     def undo(self) -> None:
         ''' Removes previously added element '''
+        if not self.elements:
+            return
         self.elements.pop(-1)
-        self.fig.clear()  # type: ignore
-        for element in self.elements:
-            element._draw(self.fig)
-        self._here, self._theta = self.elements[-1].absdrop
-        self.fig.set_bbox(self.get_bbox())  # type: ignore
-        self.fig.getimage()  # type: ignore
+        if self.elements:
+            self._here, self._theta = self.elements[-1].absdrop
+        else:
+            self._here = Point((0, 0))
+            self._theta = 0
+        if self.fig is not None:
+            self.fig.clear()
+            for element in self.elements:
+                element._draw(self.fig)
+            self.fig.set_bbox(self.get_bbox())
+            self.fig.getimage()
 
     def move(self, dx: float = 0, dy: float = 0) -> None:
         ''' Move the current drawing position

--- a/test/test_undo.py
+++ b/test/test_undo.py
@@ -1,0 +1,54 @@
+''' Tests for Drawing.undo() edge cases.
+
+    Verifies fix for issue #94: undo() raised IndexError when the
+    drawing had only one element.
+'''
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import schemdraw
+import schemdraw.elements as elm
+
+
+def test_undo_single_element():
+    ''' undo() with one element should not crash '''
+    schemdraw.use('svg')
+    with schemdraw.Drawing(show=False) as d:
+        d += elm.Resistor()
+        d.undo()
+    # Should not raise IndexError
+
+
+def test_undo_empty_drawing():
+    ''' undo() on empty drawing should be a no-op '''
+    schemdraw.use('svg')
+    with schemdraw.Drawing(show=False) as d:
+        d.undo()
+    # Should not raise
+
+
+def test_undo_then_add():
+    ''' undo all elements then add new ones '''
+    schemdraw.use('svg')
+    with schemdraw.Drawing(show=False) as d:
+        d += elm.Resistor()
+        d.undo()
+        d += elm.Capacitor()
+    # Should not raise; drawing should still be valid
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f'  PASS: {test.__name__}')
+            passed += 1
+        except Exception as e:
+            print(f'  FAIL: {test.__name__}: {e}')
+            failed += 1
+    print(f'\n{passed} passed, {failed} failed, {passed + failed} total')
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

- Fixes crashes in `Drawing.undo()` when the drawing has zero or one element

## Problem

`undo()` had three failure modes:
1. **Empty drawing**: `self.elements.pop(-1)` raises `IndexError`
2. **Single element**: after pop, `self.elements[-1].absdrop` raises `IndexError` on empty list
3. **Non-interactive mode**: `self.fig.clear()` raises `AttributeError` because `fig` is `None`

## Changes

- `schemdraw/schemdraw.py`: Guard against empty element list (early return), reset position to origin when all elements are removed, skip figure operations when `fig` is `None`
- `test/test_undo.py`: New test file covering empty drawing, single element, and undo-then-add scenarios

## Test results

Without fix: 3 of 3 tests fail
With fix: 3 of 3 tests pass

Fixes #94