### PR TITLE
Transform center in SegmentCircle.xform() for asymmetric zoom

### DIFF
--- a/schemdraw/segments.py
+++ b/schemdraw/segments.py
@@ -616,7 +616,7 @@ class SegmentCircle:
         
         # Asymmetric zoom makes circle into ellipse
         params.pop('ref', None)  # Not implemented in SegmentArc
-        return SegmentArc(self.center,
+        return SegmentArc(transform.transform(self.center),
                           width=self.radius*2*transform.zoom[0],
                           height=self.radius*2*transform.zoom[1],
                           angle=transform.theta,


### PR DESCRIPTION
## Summary

- Applies `transform.transform()` to the center when converting a circle to an arc (ellipse) under asymmetric zoom

## Problem

`SegmentCircle.xform()` correctly transforms the center for symmetric zoom (line 614) but passes the untransformed `self.center` for asymmetric zoom (line 619), causing misplaced ellipses.

## Test results

| Branch | Passed | Failed |
|--------|--------|--------|
| master | 470 | 0 |
| this branch | 470 | 0 |

Fixes #101