### PR TITLE
Skip degenerate corners in roundcorners()

### DIFF
--- a/schemdraw/segments.py
+++ b/schemdraw/segments.py
@@ -36,10 +36,6 @@ def roundcorners(verts: Sequence[XY], radius: float = .5) -> Sequence[XY]:
         dx2 = p2[0]-p3[0]
         dy2 = p2[1]-p3[1]
 
-        angle = (math.atan2(dy1, dx1) - math.atan2(dy2, dx2))/2
-        tan = abs(math.tan(angle))
-        segment = radius/tan
-
         def getlength(x, y):
             return math.sqrt(x*x + y*y)
 
@@ -49,6 +45,15 @@ def roundcorners(verts: Sequence[XY], radius: float = .5) -> Sequence[XY]:
 
         length1 = getlength(dx1, dy1)
         length2 = getlength(dx2, dy2)
+
+        if length1 < 1e-10 or length2 < 1e-10:
+            continue  # Skip degenerate corner (duplicate vertices)
+
+        angle = (math.atan2(dy1, dx1) - math.atan2(dy2, dx2))/2
+        tan = abs(math.tan(angle))
+        if tan < 1e-10:
+            continue  # Skip degenerate corner (collinear/backtracking)
+        segment = radius/tan
         length = min(length1, length2)
 
         if segment > length:

--- a/test/test_roundcorners.py
+++ b/test/test_roundcorners.py
@@ -1,0 +1,47 @@
+''' Tests for roundcorners() with degenerate inputs.
+
+    Verifies fix for issue #103: roundcorners() crashed with
+    ZeroDivisionError on duplicate or backtracking vertices.
+'''
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from schemdraw.segments import roundcorners
+
+
+def test_normal_polygon():
+    ''' Normal square polygon should work '''
+    verts = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    result = roundcorners(verts, radius=0.1)
+    assert len(result) > len(verts)
+
+
+def test_duplicate_vertices():
+    ''' Duplicate adjacent vertices should not crash '''
+    verts = [(0, 0), (1, 0), (1, 0), (1, 1), (0, 1)]
+    result = roundcorners(verts, radius=0.1)
+    assert len(result) > 0
+
+
+def test_backtracking_vertices():
+    ''' Backtracking vertices (same direction) should not crash '''
+    verts = [(0, 0), (1, 0), (0, 0), (0, 1)]
+    result = roundcorners(verts, radius=0.1)
+    assert len(result) > 0
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f'  PASS: {test.__name__}')
+            passed += 1
+        except Exception as e:
+            print(f'  FAIL: {test.__name__}: {e}')
+            failed += 1
+    print(f'\n{passed} passed, {failed} failed, {passed + failed} total')
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

- Prevents `ZeroDivisionError` in `roundcorners()` when the polygon has duplicate or backtracking vertices

## Problem

`roundcorners()` crashes with `ZeroDivisionError` in two cases:
1. **Duplicate adjacent vertices**: edge length is 0, causing division by zero in `getproportionpoint()`
2. **Backtracking vertices** (same direction from center point): `tan(angle)` is 0, causing division by zero in `segment = radius / tan`

## Changes

- `schemdraw/segments.py`: Move length calculation before angle/tan, add guards to skip degenerate corners
- `test/test_roundcorners.py`: 3 tests covering normal polygon, duplicate vertices, and backtracking vertices

## Test results

| Branch | Passed | Failed |
|--------|--------|--------|
| master | 470 | 0 |
| this branch | 473 | 0 |

Fixes #103