### PR TITLE
Return zero bbox for empty paths in Segment, SegmentPoly, SegmentPath

### DIFF
--- a/schemdraw/segments.py
+++ b/schemdraw/segments.py
@@ -155,6 +155,8 @@ class Segment:
         hw = self.arrowwidth if self.arrow else 0
         x = [p[0] for p in self.path]
         y = [p[1] for p in self.path]
+        if not x:
+            return BBox(0, 0, 0, 0)
         return BBox(min(x), min(y)-hw, max(x), max(y)+hw)
 
     def doreverse(self, centerx: float) -> None:
@@ -506,6 +508,8 @@ class SegmentPoly:
         '''
         x = [p[0] for p in self.verts]
         y = [p[1] for p in self.verts]
+        if not x:
+            return BBox(0, 0, 0, 0)
         return BBox(min(x), min(y), max(x), max(y))
 
     def draw(self, fig, transform, **style) -> None:
@@ -996,6 +1000,8 @@ class SegmentPath:
         '''
         x = [p[0] for p in self.path if not isinstance(p, str)]
         y = [p[1] for p in self.path if not isinstance(p, str)]
+        if not x:
+            return BBox(0, 0, 0, 0)
         return BBox(min(x), min(y), max(x), max(y))
 
     def doreverse(self, centerx: float) -> None:

--- a/test/test_empty_bbox.py
+++ b/test/test_empty_bbox.py
@@ -1,0 +1,61 @@
+''' Tests for get_bbox() with empty paths/vertices.
+
+    Verifies fix for issue #110: get_bbox() raised ValueError
+    on empty path/vertices lists.
+'''
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from schemdraw.segments import Segment, SegmentPoly, SegmentPath
+
+
+def test_segment_empty_path():
+    ''' Segment with empty path should return zero bbox '''
+    seg = Segment(path=[])
+    bbox = seg.get_bbox()
+    assert bbox.xmin == 0 and bbox.xmax == 0
+
+
+def test_segmentpoly_empty_verts():
+    ''' SegmentPoly with empty verts should return zero bbox '''
+    seg = SegmentPoly(verts=[])
+    bbox = seg.get_bbox()
+    assert bbox.xmin == 0 and bbox.xmax == 0
+
+
+def test_segmentpath_empty_path():
+    ''' SegmentPath with empty path should return zero bbox '''
+    seg = SegmentPath(path=[])
+    bbox = seg.get_bbox()
+    assert bbox.xmin == 0 and bbox.xmax == 0
+
+
+def test_segmentpath_only_strings():
+    ''' SegmentPath with only SVG commands (no points) should return zero bbox '''
+    seg = SegmentPath(path=['M', 'L', 'Z'])
+    bbox = seg.get_bbox()
+    assert bbox.xmin == 0 and bbox.xmax == 0
+
+
+def test_segment_normal_path():
+    ''' Non-empty path should still work '''
+    seg = Segment(path=[(0, 0), (1, 1)])
+    bbox = seg.get_bbox()
+    assert bbox.xmin == 0 and bbox.xmax == 1
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f'  PASS: {test.__name__}')
+            passed += 1
+        except Exception as e:
+            print(f'  FAIL: {test.__name__}: {e}')
+            failed += 1
+    print(f'\n{passed} passed, {failed} failed, {passed + failed} total')
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

- Prevents `ValueError` in `get_bbox()` when path/vertices list is empty

## Problem

`get_bbox()` on `Segment`, `SegmentPoly`, and `SegmentPath` crashes with `ValueError: min() iterable argument is empty` when the path or vertices list is empty (or, for `SegmentPath`, contains only string commands with no coordinate points).

## Changes

- `schemdraw/segments.py`: Add `if not x: return BBox(0, 0, 0, 0)` guard in all three affected `get_bbox()` methods
- `test/test_empty_bbox.py`: 5 tests covering empty path, empty verts, string-only path, and normal path

## Test results

| Branch | Passed | Failed |
|--------|--------|--------|
| master | 470 | 0 |
| this branch | 475 | 0 |

Fixes #110