### PR TITLE
Expand README with features, installation, and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/schemdraw.svg)](https://pypi.org/project/schemdraw/)
 [![Python versions](https://img.shields.io/pypi/pyversions/schemdraw.svg)](https://pypi.org/project/schemdraw/)
-[![Documentation Status](https://readthedocs.org/projects/schemdraw/badge/?version=latest)](https://schemdraw.readthedocs.io/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/schemdraw/badge/?version=stable)](https://schemdraw.readthedocs.io/en/stable/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 Schemdraw is a Python package for producing high-quality electrical circuit schematic diagrams. Circuit elements are added one at a time, similar to how you might draw them by hand, using Python methods to set placement and orientation.
@@ -55,16 +55,16 @@ with schemdraw.Drawing() as d:
 
 Elements are placed in a chain: each new element starts where the previous one ended. Use `.up()`, `.down()`, `.left()`, `.right()` to set direction. Use `.at()` and `.anchor()` for precise positioning.
 
-For more examples, see the [Gallery](https://schemdraw.readthedocs.io/en/latest/gallery/index.html).
+For more examples, see the [Gallery](https://schemdraw.readthedocs.io/en/stable/gallery/index.html).
 
 ## Documentation
 
 Full documentation is available at [schemdraw.readthedocs.io](https://schemdraw.readthedocs.io):
 
-- [Getting Started](https://schemdraw.readthedocs.io/en/latest/usage/start.html) -- installation and first circuit
-- [Placement & Positioning](https://schemdraw.readthedocs.io/en/latest/usage/placement.html) -- how elements connect
-- [Element Reference](https://schemdraw.readthedocs.io/en/latest/elements/electrical.html) -- all available components
-- [Gallery](https://schemdraw.readthedocs.io/en/latest/gallery/index.html) -- example circuits and diagrams
+- [Getting Started](https://schemdraw.readthedocs.io/en/stable/usage/start.html) -- installation and first circuit
+- [Placement & Positioning](https://schemdraw.readthedocs.io/en/stable/usage/placement.html) -- how elements connect
+- [Element Reference](https://schemdraw.readthedocs.io/en/stable/elements/electrical.html) -- all available components
+- [Gallery](https://schemdraw.readthedocs.io/en/stable/gallery/index.html) -- example circuits and diagrams
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,75 @@
 # schemdraw
 
-Schemdraw is a python package for producing high-quality electrical circuit schematic diagrams. Typical usage:
+[![PyPI version](https://img.shields.io/pypi/v/schemdraw.svg)](https://pypi.org/project/schemdraw/)
+[![Python versions](https://img.shields.io/pypi/pyversions/schemdraw.svg)](https://pypi.org/project/schemdraw/)
+[![Documentation Status](https://readthedocs.org/projects/schemdraw/badge/?version=latest)](https://schemdraw.readthedocs.io/en/latest/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+Schemdraw is a Python package for producing high-quality electrical circuit schematic diagrams. Circuit elements are added one at a time, similar to how you might draw them by hand, using Python methods to set placement and orientation.
+
+## Features
+
+- **Electrical elements** -- resistors, capacitors, inductors, diodes, transistors, op-amps, sources, transformers, vacuum tubes, and more
+- **Integrated circuits** -- configurable IC packages with arbitrary pin count and labeling
+- **Logic gates** -- AND, OR, NOT, XOR, flip-flops, and multiplexers
+- **Timing diagrams** -- digital waveforms with clock, data, and edge annotations
+- **Signal processing** -- DSP blocks, filters, mixers, and amplifiers
+- **Flowcharts** -- decision, process, and data blocks with automatic connectors
+- **Pictorial elements** -- breadboard-style and Fritzing-compatible components
+- **Multiple backends** -- Matplotlib (PNG, PDF, EPS) and native SVG output
+- **Jupyter integration** -- renders inline in notebooks with no extra configuration
+- **LaTeX-style math** -- label elements with superscripts, subscripts, and Greek symbols
+- **Type hints** -- full type annotation support (`py.typed`)
+
+## Installation
+
+Install from PyPI:
+
+```bash
+pip install schemdraw
+```
+
+Optional dependencies for additional features:
+
+```bash
+# Matplotlib backend (PNG, PDF, EPS export)
+pip install schemdraw[matplotlib]
+
+# Math rendering in native SVG backend
+pip install schemdraw[svgmath]
+```
+
+## Quick start
 
 ```python
 import schemdraw
 import schemdraw.elements as elm
-with schemdraw.Drawing(file='schematic.svg') as d:
-    elm.Resistor().label('100KΩ')
-    elm.Capacitor().down().label('0.1μF', loc='bottom')
+
+with schemdraw.Drawing() as d:
+    elm.Resistor().label('100K\u03A9')
+    elm.Capacitor().down().label('0.1\u00B5F', loc='bottom')
     elm.Line().left()
     elm.Ground()
     elm.SourceV().up().label('10V')
 ```
 
-Included are symbols for basic electrical components (resistors, capacitors, diodes, transistors, etc.), opamps and signal processing elements. Additionally, Schemdraw can produce digital timing diagrams, state machine diagrams, and flowcharts.
+Elements are placed in a chain: each new element starts where the previous one ended. Use `.up()`, `.down()`, `.left()`, `.right()` to set direction. Use `.at()` and `.anchor()` for precise positioning.
 
-Documentation is available at [readthedocs](https://schemdraw.readthedocs.io)
+For more examples, see the [Gallery](https://schemdraw.readthedocs.io/en/latest/gallery/index.html).
 
-The most current version can be found in the [source code git repository](https://github.com/cdelker/schemdraw).
+## Documentation
+
+Full documentation is available at [schemdraw.readthedocs.io](https://schemdraw.readthedocs.io):
+
+- [Getting Started](https://schemdraw.readthedocs.io/en/latest/usage/start.html) -- installation and first circuit
+- [Placement & Positioning](https://schemdraw.readthedocs.io/en/latest/usage/placement.html) -- how elements connect
+- [Element Reference](https://schemdraw.readthedocs.io/en/latest/elements/electrical.html) -- all available components
+- [Gallery](https://schemdraw.readthedocs.io/en/latest/gallery/index.html) -- example circuits and diagrams
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting issues, submitting pull requests, and setting up a development environment.
+
+## License
+
+Schemdraw is licensed under the [MIT License](LICENSE.txt).


### PR DESCRIPTION
## Summary

Expands the README from a 21-line stub to a comprehensive project overview following conventions of major Python libraries.

## Changes

- Added PyPI, Python version, docs, and license badges
- Added feature highlights covering all element categories (electrical, IC, logic, timing, DSP, flow, pictorial)
- Added installation instructions with optional dependency extras
- Expanded quick start example with explanation of the placement model
- Added links to key documentation sections (using /stable/ URLs)
- Added contributing and license sections

## Notes

The README serves as `long_description` for PyPI (via `setup.cfg`), so these improvements will also appear on the PyPI project page.

## Test results

| Branch | Passed | Failed |
|--------|--------|--------|
| master | 470 | 0 |
| this branch | 470 | 0 |

Fixes #117