### PR TITLE
Add GitHub Actions CI workflow for tests and linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,11 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install flake8
-      - name: Run flake8
+      # Non-blocking: existing codebase has pre-existing formatting
+      # warnings (whitespace, indentation, line length). These will
+      # be addressed in a future PR. Remove continue-on-error once
+      # the cleanup is done.
+      - name: Run flake8 (informational)
         run: flake8 schemdraw/
         continue-on-error: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,9 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && matrix.python-version == '3.12' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: junit.xml
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install flake8
@@ -29,8 +29,8 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,4 +48,5 @@ jobs:
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,14 @@ jobs:
         run: |
           pip install .
           pip install ".[matplotlib,svgmath]"
-          pip install pytest nbval ipykernel
+          pip install pytest nbval ipykernel pytest-cov
           python -m ipykernel install --user
 
       - name: Run tests
-        run: python -m pytest --nbval-lax test/ -q
+        run: python -m pytest --nbval-lax --cov=schemdraw test/ -q
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install flake8
+      - run: flake8 schemdraw/
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install .
+          pip install ".[matplotlib,svgmath]"
+          pip install pytest nbval ipykernel
+          python -m ipykernel install --user
+
+      - name: Run tests
+        run: python -m pytest --nbval-lax test/ -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           python -m ipykernel install --user
 
       - name: Run tests
-        run: python -m pytest --nbval-lax --cov=schemdraw test/ -q
+        run: python -m pytest --nbval-lax --cov=schemdraw --junitxml=junit.xml -o junit_family=legacy test/ -q
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
@@ -50,3 +50,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && matrix.python-version == '3.12' }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install flake8
-      - run: flake8 schemdraw/
+      - name: Run flake8
+        run: flake8 schemdraw/
+        continue-on-error: true
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs automatically on pushes to `master` and on pull requests.

## What it does

- **Linting**: runs `flake8` (informational, non-blocking due to pre-existing formatting warnings — to be cleaned up in a future PR)
- **Testing**: runs the full test suite (`pytest --nbval-lax test/`) across Python 3.9, 3.10, 3.11, 3.12, and 3.13
- **Coverage**: generates test coverage with `pytest-cov` and uploads to [Codecov](https://about.codecov.io/) (from the Python 3.12 job)
- **Test Analytics**: uploads JUnit XML results to Codecov for test run time tracking and flaky test detection
- Uses `actions/checkout@v5` and `actions/setup-python@v6` (Node.js 24)

## Cost

GitHub Actions and Codecov are both free for public repositories.

## Setup required after merging

The repository owner needs to configure Codecov once (see [issue #119](https://github.com/cdelker/schemdraw/issues/119) for step-by-step instructions):

1. Sign in at [app.codecov.io](https://app.codecov.io/) with GitHub
2. Enable the `schemdraw` repository
3. Copy the repository upload token
4. Add it as a GitHub Actions secret named `CODECOV_TOKEN`

The workflow will work without the token (coverage upload will silently skip via `fail_ci_if_error: false`), but Codecov features (PR comments, dashboards, test analytics) require it.

## Verified

Tested on fork with full Codecov integration working:
- CI run: https://github.com/leofernandezg/schemdraw/actions/runs/23612285177
- Coverage report: https://app.codecov.io/github/leofernandezg/schemdraw

Current test coverage: ~57% (510 tests)

## Test results

| Branch | Passed | Failed |
|--------|--------|--------|
| master | 470 | 0 |
| this branch | 470 | 0 |

Fixes #119